### PR TITLE
Add legacy li.fi contract address

### DIFF
--- a/contracts/1/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
+++ b/contracts/1/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
@@ -1,0 +1,5 @@
+{
+  "name": "Li.Fi",
+  "logoURI": "raw.githubusercontent.com/block-wallet/assets/master/dapps/li.fi.png",
+  "websiteURL": "https://li.fi/"
+}

--- a/contracts/10/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
+++ b/contracts/10/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
@@ -1,0 +1,5 @@
+{
+  "name": "Li.Fi",
+  "logoURI": "raw.githubusercontent.com/block-wallet/assets/master/dapps/li.fi.png",
+  "websiteURL": "https://li.fi/"
+}

--- a/contracts/100/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
+++ b/contracts/100/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
@@ -1,0 +1,5 @@
+{
+  "name": "Li.Fi",
+  "logoURI": "raw.githubusercontent.com/block-wallet/assets/master/dapps/li.fi.png",
+  "websiteURL": "https://li.fi/"
+}

--- a/contracts/122/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
+++ b/contracts/122/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
@@ -1,0 +1,5 @@
+{
+  "name": "Li.Fi",
+  "logoURI": "raw.githubusercontent.com/block-wallet/assets/master/dapps/li.fi.png",
+  "websiteURL": "https://li.fi/"
+}

--- a/contracts/1284/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
+++ b/contracts/1284/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
@@ -1,0 +1,5 @@
+{
+  "name": "Li.Fi",
+  "logoURI": "raw.githubusercontent.com/block-wallet/assets/master/dapps/li.fi.png",
+  "websiteURL": "https://li.fi/"
+}

--- a/contracts/1285/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
+++ b/contracts/1285/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
@@ -1,0 +1,5 @@
+{
+  "name": "Li.Fi",
+  "logoURI": "raw.githubusercontent.com/block-wallet/assets/master/dapps/li.fi.png",
+  "websiteURL": "https://li.fi/"
+}

--- a/contracts/137/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
+++ b/contracts/137/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
@@ -1,0 +1,5 @@
+{
+  "name": "Li.Fi",
+  "logoURI": "raw.githubusercontent.com/block-wallet/assets/master/dapps/li.fi.png",
+  "websiteURL": "https://li.fi/"
+}

--- a/contracts/1666600000/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
+++ b/contracts/1666600000/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
@@ -1,0 +1,5 @@
+{
+  "name": "Li.Fi",
+  "logoURI": "raw.githubusercontent.com/block-wallet/assets/master/dapps/li.fi.png",
+  "websiteURL": "https://li.fi/"
+}

--- a/contracts/250/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
+++ b/contracts/250/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
@@ -1,0 +1,5 @@
+{
+  "name": "Li.Fi",
+  "logoURI": "raw.githubusercontent.com/block-wallet/assets/master/dapps/li.fi.png",
+  "websiteURL": "https://li.fi/"
+}

--- a/contracts/42161/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
+++ b/contracts/42161/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
@@ -1,0 +1,5 @@
+{
+  "name": "Li.Fi",
+  "logoURI": "raw.githubusercontent.com/block-wallet/assets/master/dapps/li.fi.png",
+  "websiteURL": "https://li.fi/"
+}

--- a/contracts/42220/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
+++ b/contracts/42220/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
@@ -1,0 +1,5 @@
+{
+  "name": "Li.Fi",
+  "logoURI": "raw.githubusercontent.com/block-wallet/assets/master/dapps/li.fi.png",
+  "websiteURL": "https://li.fi/"
+}

--- a/contracts/43114/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
+++ b/contracts/43114/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
@@ -1,0 +1,5 @@
+{
+  "name": "Li.Fi",
+  "logoURI": "raw.githubusercontent.com/block-wallet/assets/master/dapps/li.fi.png",
+  "websiteURL": "https://li.fi/"
+}

--- a/contracts/56/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
+++ b/contracts/56/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
@@ -1,0 +1,5 @@
+{
+  "name": "Li.Fi",
+  "logoURI": "raw.githubusercontent.com/block-wallet/assets/master/dapps/li.fi.png",
+  "websiteURL": "https://li.fi/"
+}

--- a/contracts/66/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
+++ b/contracts/66/0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f.json
@@ -1,0 +1,5 @@
+{
+  "name": "Li.Fi",
+  "logoURI": "raw.githubusercontent.com/block-wallet/assets/master/dapps/li.fi.png",
+  "websiteURL": "https://li.fi/"
+}

--- a/known-dapps.json
+++ b/known-dapps.json
@@ -41,46 +41,60 @@
         "name": "Li.Fi",
         "contractAddresses": {
             "1": [
-                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+                "0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f"
             ],
             "10": [
-                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+                "0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f"
             ],
             "56": [
-                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+                "0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f"
             ],
             "100": [
-                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+                "0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f"
             ],
             "122": [
-                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+                "0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f"
             ],
             "66": [
-                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+                "0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f"
             ],
             "137": [
-                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+                "0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f"
             ],
             "250": [
-                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+                "0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f"
             ],
             "1284": [
-                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+                "0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f"
             ],
             "1285": [
-                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+                "0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f"
             ],
             "42161": [
-                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+                "0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f"
             ],
             "42220": [
-                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+                "0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f"
             ],
             "43114": [
-                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+                "0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f"
             ],
             "1666600000": [
-                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+                "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+                "0x362fA9D0bCa5D19f743Db50738345ce2b40eC99f"
             ]
         },
         "logoURI": ""


### PR DESCRIPTION
This PR adds a Li.Fi legacy contract address to the known-dapps list